### PR TITLE
Support Tigerbeetle 0.15.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -533,7 +533,7 @@ dependencies = [
 
 [[package]]
 name = "tigerbeetle-unofficial"
-version = "0.4.0+0.15.3"
+version = "0.4.1+0.15.5"
 dependencies = [
  "bytemuck",
  "pollster",
@@ -543,7 +543,7 @@ dependencies = [
 
 [[package]]
 name = "tigerbeetle-unofficial-core"
-version = "0.4.0+0.15.3"
+version = "0.4.1+0.15.5"
 dependencies = [
  "bytemuck",
  "sptr",
@@ -553,7 +553,7 @@ dependencies = [
 
 [[package]]
 name = "tigerbeetle-unofficial-sys"
-version = "0.4.0+0.15.3"
+version = "0.4.1+0.15.5"
 dependencies = [
  "bindgen",
  "bitflags 2.6.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ pollster = { version = "0.3.0", features = ["macro"] }
 members = ["sys", "core"]
 
 [workspace.package]
-version = "0.4.1+0.15.3"
+version = "0.4.1+0.15.5"
 authors = ["Daria Sukhonina <dariasukhonina@gmail.com>"]
 rust-version = "1.78"
 repository = "https://github.com/ZetaNumbers/tigerbeetle-rs"

--- a/core/examples/c_port_low_level.rs
+++ b/core/examples/c_port_low_level.rs
@@ -162,14 +162,14 @@ impl CompletionContext {
         &self,
         mut guard: MutexGuard<'a, CompletionState>,
         packet: tb::Packet<Box<UserData>>,
-    ) -> Result<(Box<UserData>, MutexGuard<'a, CompletionState>), tb::error::SendError> {
+    ) -> Result<(Box<UserData>, MutexGuard<'a, CompletionState>), tb::error::SubmitError> {
         guard.completed = None;
-        packet.submit();
+        packet.submit()?;
         loop {
             guard = self.cv.wait(guard).unwrap();
 
             if let Some(c) = guard.completed.take() {
-                break c.1.map(|()| (c.0, guard));
+                break Ok(c.1.map(|()| (c.0, guard))?);
             }
         }
     }

--- a/core/examples/c_port_low_level.rs
+++ b/core/examples/c_port_low_level.rs
@@ -5,7 +5,7 @@ use std::{
     time::{Duration, Instant},
 };
 
-use tigerbeetle_unofficial_core as tb;
+use tigerbeetle_unofficial_core::{self as tb, Packet};
 
 const MAX_MESSAGE_SIZE: usize = (1024 * 1024) - 256;
 
@@ -35,7 +35,7 @@ fn main() {
     println!("Connecting...");
     let address = std::env::var("TB_ADDRESS");
     let address = address.as_deref().unwrap_or("3000");
-    let client = tb::Client::with_callback(0, address.as_bytes(), 32, &Callbacks)
+    let client = tb::Client::with_callback(0, address.as_bytes(), &Callbacks)
         .expect("Failed to initialize tigerbeetle client");
 
     static CTX: CompletionContext = CompletionContext::new();
@@ -51,9 +51,11 @@ fn main() {
         data_size: 0,
     });
     user_data.set_data(accounts);
-    let mut packet = client
-        .acquire(user_data, tb::OperationKind::CreateAccounts.into())
-        .unwrap();
+    let mut packet = Packet::new(
+        client.handle(),
+        user_data,
+        tb::OperationKind::CreateAccounts.into(),
+    );
     println!("Creating accounts...");
     let mut state = CTX.state.lock().unwrap();
     (user_data, state) = CTX.send_request(state, packet).unwrap();
@@ -85,9 +87,11 @@ fn main() {
                 .with_amount(1)
         });
         user_data.set_data(transfers);
-        packet = client
-            .acquire(user_data, tb::OperationKind::CreateTransfers.into())
-            .unwrap();
+        packet = Packet::new(
+            client.handle(),
+            user_data,
+            tb::OperationKind::CreateTransfers.into(),
+        );
 
         let now = Instant::now();
         (user_data, state) = CTX.send_request(state, packet).unwrap();
@@ -125,9 +129,11 @@ fn main() {
     println!("Looking up accounts ...");
     let ids = accounts.map(|a| a.id());
     user_data.set_data(ids);
-    packet = client
-        .acquire(user_data, tb::OperationKind::LookupAccounts.into())
-        .unwrap();
+    packet = Packet::new(
+        client.handle(),
+        user_data,
+        tb::OperationKind::LookupAccounts.into(),
+    );
     (_, state) = CTX.send_request(state, packet).unwrap();
     let accounts = state.get_data::<tb::Account>();
     if accounts.is_empty() {

--- a/core/src/callback.rs
+++ b/core/src/callback.rs
@@ -1,4 +1,10 @@
-use std::{marker::PhantomData, mem::ManuallyDrop, panic::catch_unwind, slice};
+use std::{
+    marker::PhantomData,
+    mem::ManuallyDrop,
+    panic::catch_unwind,
+    slice,
+    sync::{Arc, Mutex},
+};
 
 use crate::util::RawConstPtr;
 
@@ -108,7 +114,7 @@ pub(crate) unsafe extern "C" fn on_completion_raw_fn<F>(
         let packet = Packet {
             raw: ManuallyDrop::new(packet),
             handle: super::ClientHandle {
-                raw: raw_client,
+                raw: Arc::new(Mutex::new(raw_client)),
                 on_completion: cb,
             },
         };

--- a/core/src/callback.rs
+++ b/core/src/callback.rs
@@ -1,4 +1,4 @@
-use std::{marker::PhantomData, panic::catch_unwind, slice};
+use std::{marker::PhantomData, mem::ManuallyDrop, panic::catch_unwind, slice};
 
 use crate::util::RawConstPtr;
 
@@ -106,7 +106,7 @@ pub(crate) unsafe extern "C" fn on_completion_raw_fn<F>(
             &[]
         };
         let packet = Packet {
-            raw: packet,
+            raw: ManuallyDrop::new(packet),
             handle: super::ClientHandle {
                 raw: raw_client,
                 on_completion: cb,

--- a/core/src/handle.rs
+++ b/core/src/handle.rs
@@ -1,9 +1,4 @@
-use std::{ffi::c_void, ptr};
-
-use super::{
-    callback::{Callbacks, UserDataPtr},
-    packet, Packet,
-};
+use super::callback::{Callbacks, UserDataPtr};
 
 pub struct ClientHandle<'a, U>
 where
@@ -24,32 +19,5 @@ where
 {
     fn clone(&self) -> Self {
         *self
-    }
-}
-
-impl<'a, U> ClientHandle<'a, U>
-where
-    U: UserDataPtr,
-{
-    pub fn acquire(self, user_data: U, operation: packet::Operation) -> Packet<'a, U> {
-        let user_data = U::into_raw_const_ptr(user_data).cast::<c_void>().cast_mut();
-
-        let raw = Box::new(sys::tb_packet_t {
-            next: ptr::null_mut(),
-            user_data,
-            operation: operation.0,
-            status: 0,
-            data_size: 0,
-            data: ptr::null_mut(),
-            batch_next: ptr::null_mut(),
-            batch_tail: ptr::null_mut(),
-            batch_size: 0,
-            reserved: [0; 8],
-        });
-
-        Packet {
-            raw: Box::into_raw(raw).cast(),
-            handle: self,
-        }
     }
 }

--- a/core/src/handle.rs
+++ b/core/src/handle.rs
@@ -1,23 +1,29 @@
+use std::sync::{Arc, Mutex};
+
 use super::callback::{Callbacks, UserDataPtr};
 
 pub struct ClientHandle<'a, U>
 where
     U: UserDataPtr,
 {
-    pub(crate) raw: sys::tb_client_t,
+    pub(crate) raw: Arc<Mutex<sys::tb_client_t>>,
     pub(crate) on_completion: &'a dyn Callbacks<UserDataPtr = U>,
 }
 
 unsafe impl<U> Send for ClientHandle<'_, U> where U: UserDataPtr {}
 unsafe impl<U> Sync for ClientHandle<'_, U> where U: UserDataPtr {}
 
-impl<U> Copy for ClientHandle<'_, U> where U: UserDataPtr {}
+// impl<U> Copy for ClientHandle<'_, U> where U: UserDataPtr {}
 
 impl<U> Clone for ClientHandle<'_, U>
 where
     U: UserDataPtr,
 {
     fn clone(&self) -> Self {
-        *self
+        // *self
+        Self {
+            raw: self.raw.clone(),
+            on_completion: self.on_completion,
+        }
     }
 }

--- a/core/src/handle.rs
+++ b/core/src/handle.rs
@@ -1,6 +1,4 @@
-use std::{ffi::c_void, num::NonZeroU32, ptr};
-
-use crate::error::AcquirePacketError;
+use std::{ffi::c_void, ptr};
 
 use super::{
     callback::{Callbacks, UserDataPtr},
@@ -33,35 +31,25 @@ impl<'a, U> ClientHandle<'a, U>
 where
     U: UserDataPtr,
 {
-    pub fn acquire(
-        self,
-        user_data: U,
-        operation: packet::Operation,
-    ) -> Result<Packet<'a, U>, AcquirePacketError> {
-        unsafe fn impl_(
-            raw_client: sys::tb_client_t,
-            user_data: *const c_void,
-            operation: u8,
-        ) -> Result<*mut sys::tb_packet_t, AcquirePacketError> {
-            let mut raw = ptr::null_mut();
-            let status = sys::tb_client_acquire_packet(raw_client, &mut raw);
-            if let Some(c) = NonZeroU32::new(status) {
-                return Err(AcquirePacketError(c));
-            }
-            raw.write(sys::tb_packet_t {
-                next: ptr::null_mut(),
-                user_data: user_data.cast_mut(),
-                operation,
-                status: 0,
-                data_size: 0,
-                data: ptr::null_mut(),
-            });
-            Ok(raw)
+    pub fn acquire(self, user_data: U, operation: packet::Operation) -> Packet<'a, U> {
+        let user_data = U::into_raw_const_ptr(user_data).cast::<c_void>().cast_mut();
+
+        let raw = Box::new(sys::tb_packet_t {
+            next: ptr::null_mut(),
+            user_data,
+            operation: operation.0,
+            status: 0,
+            data_size: 0,
+            data: ptr::null_mut(),
+            batch_next: ptr::null_mut(),
+            batch_tail: ptr::null_mut(),
+            batch_size: 0,
+            reserved: [0; 8],
+        });
+
+        Packet {
+            raw: Box::into_raw(raw).cast(),
+            handle: self,
         }
-
-        let user_data = U::into_raw_const_ptr(user_data);
-
-        let raw = unsafe { impl_(self.raw, user_data.cast(), operation.0)? };
-        Ok(Packet { raw, handle: self })
     }
 }

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -124,14 +124,6 @@ where
             on_completion: unsafe { &*self.on_completion },
         }
     }
-
-    pub fn acquire(
-        &self,
-        user_data: F::UserDataPtr,
-        operation: packet::Operation,
-    ) -> Packet<'_, F::UserDataPtr> {
-        self.handle().acquire(user_data, operation)
-    }
 }
 
 /// Blocks until all pending requests finish

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -8,7 +8,7 @@ pub mod util;
 
 use std::{marker::PhantomData, mem, num::NonZeroU32};
 
-use error::{AcquirePacketError, NewClientError, NewClientErrorKind};
+use error::{NewClientError, NewClientErrorKind};
 
 pub use account::Account;
 pub use callback::*;
@@ -38,7 +38,6 @@ where
     pub fn with_callback<A>(
         cluster_id: u128,
         address: A,
-        concurrency_max: u32,
         on_completion: F,
     ) -> Result<Self, NewClientError>
     where
@@ -50,9 +49,7 @@ where
         F::UserDataPtr: 'static,
     {
         // SAFETY: F and UserData are 'static
-        unsafe {
-            Client::with_callback_unchecked(cluster_id, address, concurrency_max, on_completion)
-        }
+        unsafe { Client::with_callback_unchecked(cluster_id, address, on_completion) }
     }
 
     /// Highly unsafe method. Please use [`Self::with_callback`]
@@ -67,7 +64,6 @@ where
     pub unsafe fn with_callback_unchecked<A>(
         cluster_id: u128,
         address: A,
-        concurrency_max: u32,
         on_completion: F,
     ) -> Result<Self, NewClientError>
     where
@@ -80,7 +76,6 @@ where
         unsafe fn raw_with_callback(
             cluster_id: u128,
             address: &[u8],
-            concurrency_max: u32,
             on_completion_ctx: usize,
             on_completion_fn: OnCompletionRawFn,
         ) -> Result<sys::tb_client_t, NewClientError> {
@@ -93,7 +88,6 @@ where
                     .len()
                     .try_into()
                     .map_err(|_| NewClientErrorKind::AddressInvalid)?,
-                concurrency_max,
                 on_completion_ctx,
                 Some(on_completion_fn),
             );
@@ -109,7 +103,6 @@ where
                 match raw_with_callback(
                     cluster_id,
                     address.as_ref(),
-                    concurrency_max,
                     on_completion_ctx,
                     on_completion_fn,
                 ) {
@@ -136,7 +129,7 @@ where
         &self,
         user_data: F::UserDataPtr,
         operation: packet::Operation,
-    ) -> Result<Packet<'_, F::UserDataPtr>, AcquirePacketError> {
+    ) -> Packet<'_, F::UserDataPtr> {
         self.handle().acquire(user_data, operation)
     }
 }

--- a/core/src/packet.rs
+++ b/core/src/packet.rs
@@ -62,7 +62,7 @@ where
         let user_data;
         unsafe {
             user_data = U::from_raw_const_ptr(this.raw().user_data.cast_const().cast());
-            sys::tb_client_release_packet(this.handle.raw, this.raw);
+            let _raw = Box::from_raw(this.raw);
         }
         user_data
     }
@@ -131,7 +131,6 @@ where
     fn drop(&mut self) {
         unsafe {
             U::from_raw_const_ptr(self.raw().user_data.cast_const().cast());
-            sys::tb_client_release_packet(self.handle.raw, self.raw);
         }
     }
 }

--- a/examples/c_port_high_level.rs
+++ b/examples/c_port_high_level.rs
@@ -11,7 +11,7 @@ async fn main() {
     println!("Connecting...");
     let address = std::env::var("TB_ADDRESS");
     let address = address.as_deref().unwrap_or("3000");
-    let client = tb::Client::new(0, address, 32).expect("creating a tigerbeetle client");
+    let client = tb::Client::new(0, address).expect("creating a tigerbeetle client");
 
     ////////////////////////////////////////////////////////////
     // Submitting a batch of accounts:                        //

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@ use tokio::sync::oneshot;
 use core::{
     error::{CreateAccountsError, CreateTransfersError, SendError},
     util::{RawConstPtr, SendAsBytesOwnedSlice, SendOwnedSlice},
+    Packet,
 };
 
 pub use core::{self, account, error, transfer, Account, Transfer};
@@ -136,7 +137,9 @@ impl Client {
     ) -> Result<Reply, SendError> {
         let (reply_sender, reply_receiver) = oneshot::channel();
         let user_data = Box::new(UserData { reply_sender, data });
-        let packet = self.inner.acquire(user_data, operation);
+
+        let packet = Packet::new(self.inner.handle(), user_data, operation);
+
         packet.submit();
         reply_receiver.await.unwrap()
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,11 +2,9 @@
 
 mod reply;
 
-use std::sync::Arc;
-
-use error::{NewClientError, NewClientErrorKind};
+use error::NewClientError;
 use reply::Reply;
-use tokio::sync::{oneshot, OwnedSemaphorePermit, Semaphore};
+use tokio::sync::oneshot;
 
 use core::{
     error::{CreateAccountsError, CreateTransfersError, SendError},
@@ -17,33 +15,22 @@ pub use core::{self, account, error, transfer, Account, Transfer};
 
 pub struct Client {
     inner: core::Client<&'static Callbacks>,
-    sema: Arc<Semaphore>,
 }
 
 struct Callbacks;
 
 struct UserData {
     reply_sender: oneshot::Sender<Result<Reply, SendError>>,
-    _permit: OwnedSemaphorePermit,
     data: SendAsBytesOwnedSlice,
 }
 
 impl Client {
-    pub fn new<A>(
-        cluster_id: u128,
-        address: A,
-        concurrency_max: u32,
-    ) -> Result<Self, NewClientError>
+    pub fn new<A>(cluster_id: u128, address: A) -> Result<Self, NewClientError>
     where
         A: AsRef<[u8]>,
     {
         Ok(Client {
-            sema: Arc::new(Semaphore::new(
-                concurrency_max
-                    .try_into()
-                    .map_err(|_| NewClientErrorKind::ConcurrencyMaxInvalid)?,
-            )),
-            inner: core::Client::with_callback(cluster_id, address, concurrency_max, &Callbacks)?,
+            inner: core::Client::with_callback(cluster_id, address, &Callbacks)?,
         })
     }
 
@@ -147,14 +134,9 @@ impl Client {
         data: SendAsBytesOwnedSlice,
         operation: core::Operation,
     ) -> Result<Reply, SendError> {
-        let permit = self.sema.clone().acquire_owned().await.unwrap();
         let (reply_sender, reply_receiver) = oneshot::channel();
-        let user_data = Box::new(UserData {
-            reply_sender,
-            _permit: permit,
-            data,
-        });
-        let packet = self.inner.acquire(user_data, operation).unwrap();
+        let user_data = Box::new(UserData { reply_sender, data });
+        let packet = self.inner.acquire(user_data, operation);
         packet.submit();
         reply_receiver.await.unwrap()
     }

--- a/sys/build.rs
+++ b/sys/build.rs
@@ -104,7 +104,11 @@ fn main() {
         .args((!debug).then_some("-Drelease"))
         .arg(format!("-Dtarget={tigerbeetle_target}"))
         .arg("-Dconfig-log-level=debug")
-        .env("TIGERBEETLE_RELEASE", TIGERBEETLE_RELEASE)
+        .arg(format!("-Dconfig-release={}", TIGERBEETLE_RELEASE))
+        .arg(format!(
+            "-Dconfig-release-client-min={}",
+            TIGERBEETLE_RELEASE
+        ))
         .current_dir(&tigerbeetle_root)
         .status()
         .expect("running zig build subcommand");

--- a/sys/build.rs
+++ b/sys/build.rs
@@ -12,14 +12,27 @@ use std::{
 use quote::quote;
 use syn::visit::Visit;
 
-const TIGERBEETLE_RELEASE: &str = "0.15.3";
+const TIGERBEETLE_RELEASE: &str = "0.15.5";
 
 fn target_to_lib_dir(target: &str) -> Option<&'static str> {
     match target {
-        "aarch64-unknown-linux-gnu" => Some("aarch64-linux-gnu"),
+        "aarch64-unknown-linux-gnu" => Some("aarch64-linux-gnu.2.27"),
         "aarch64-unknown-linux-musl" => Some("aarch64-linux-musl"),
         "aarch64-apple-darwin" => Some("aarch64-macos"),
-        "x86_64-unknown-linux-gnu" => Some("x86_64-linux-gnu"),
+        "x86_64-unknown-linux-gnu" => Some("x86_64-linux-gnu.2.27"),
+        "x86_64-unknown-linux-musl" => Some("x86_64-linux-musl"),
+        "x86_64-apple-darwin" => Some("x86_64-macos"),
+        "x86_64-pc-windows-msvc" => Some("x86_64-windows"),
+        _ => None,
+    }
+}
+
+fn target_to_tigerbeetle_target(target: &str) -> Option<&'static str> {
+    match target {
+        "aarch64-unknown-linux-gnu" => Some("aarch64-linux"),
+        "aarch64-unknown-linux-musl" => Some("aarch64-linux-musl"),
+        "aarch64-apple-darwin" => Some("aarch64-macos"),
+        "x86_64-unknown-linux-gnu" => Some("x86_64-linux"),
         "x86_64-unknown-linux-musl" => Some("x86_64-linux-musl"),
         "x86_64-apple-darwin" => Some("x86_64-macos"),
         "x86_64-pc-windows-msvc" => Some("x86_64-windows"),
@@ -37,6 +50,7 @@ fn main() {
     let out_dir: PathBuf = env::var("OUT_DIR").unwrap().into();
     let debug: bool = env::var("DEBUG").unwrap().parse().unwrap();
     let target = env::var("TARGET").unwrap();
+    println!("Target: {:?}", target);
 
     println!("cargo:rerun-if-env-changed=DOCS_RS");
     println!("cargo:rerun-if-changed=src/wrapper.h");
@@ -46,6 +60,9 @@ fn main() {
         wrapper = "src/wrapper.h".into();
     } else {
         let target_lib_subdir = target_to_lib_dir(&target)
+            .unwrap_or_else(|| panic!("target {target:?} is not supported"));
+
+        let tigerbeetle_target = target_to_tigerbeetle_target(&target)
             .unwrap_or_else(|| panic!("target {target:?} is not supported"));
 
         let tigerbeetle_root = out_dir.join("tigerbeetle");
@@ -61,23 +78,20 @@ fn main() {
         create_mirror(
             "tigerbeetle".as_ref(),
             &tigerbeetle_root,
-            &["src/clients/c/lib", "zig-cache", "zig-out", "zig", ".git"]
+            &["src/clients/c/lib", "zig-cache", "zig-out", ".git"]
                 .into_iter()
                 .collect(),
         );
 
         let status = Command::new(
             tigerbeetle_root
-                .join("scripts/install_zig")
+                .join("zig/download")
                 .with_extension(SCRIPT_EXTENSION),
         )
         .current_dir(&tigerbeetle_root)
         .status()
-        .expect("running install_zig script");
-        assert!(
-            status.success(),
-            "install_zig script failed with {status:?}"
-        );
+        .expect("running download script");
+        assert!(status.success(), "download script failed with {status:?}");
 
         let status = Command::new(
             tigerbeetle_root
@@ -87,15 +101,16 @@ fn main() {
                 .unwrap(),
         )
         .arg("build")
-        .arg("c_client")
+        .arg("clients:c")
         .args((!debug).then_some("-Drelease"))
-        .arg(format!("-Dtarget={target_lib_subdir}"))
+        .arg(format!("-Dtarget={tigerbeetle_target}"))
         .env("TIGERBEETLE_RELEASE", TIGERBEETLE_RELEASE)
         .current_dir(&tigerbeetle_root)
         .status()
         .expect("running zig build subcommand");
         assert!(status.success(), "zig build failed with {status:?}");
 
+        let c_dir = tigerbeetle_root.join("src/clients/c/");
         let lib_dir = tigerbeetle_root.join("src/clients/c/lib");
         let link_search = lib_dir.join(target_lib_subdir);
         println!(
@@ -106,8 +121,8 @@ fn main() {
         );
         println!("cargo:rustc-link-lib=static=tb_client");
 
-        wrapper = lib_dir.join("include/wrapper.h");
-        let generated_header = lib_dir.join("include/tb_client.h");
+        wrapper = c_dir.join("wrapper.h");
+        let generated_header = c_dir.join("tb_client.h");
         assert!(
             std::fs::read_to_string(&generated_header).expect("reading generated `tb_client.h`")
                 == std::fs::read_to_string("src/tb_client.h")

--- a/sys/build.rs
+++ b/sys/build.rs
@@ -50,7 +50,6 @@ fn main() {
     let out_dir: PathBuf = env::var("OUT_DIR").unwrap().into();
     let debug: bool = env::var("DEBUG").unwrap().parse().unwrap();
     let target = env::var("TARGET").unwrap();
-    println!("Target: {:?}", target);
 
     println!("cargo:rerun-if-env-changed=DOCS_RS");
     println!("cargo:rerun-if-changed=src/wrapper.h");
@@ -104,6 +103,7 @@ fn main() {
         .arg("clients:c")
         .args((!debug).then_some("-Drelease"))
         .arg(format!("-Dtarget={tigerbeetle_target}"))
+        .arg("-Dconfig-log-level=debug")
         .env("TIGERBEETLE_RELEASE", TIGERBEETLE_RELEASE)
         .current_dir(&tigerbeetle_root)
         .status()


### PR DESCRIPTION
This adds support for Tigerbeetle `0.15.5`. Besides a few bits accommodating changes to `build.zig`, the significant changes are support for client-side allocation of packets (the API was removed in `0.15.4`) and locking around access to `tb_client_t` when sending packets or deconstructing. This was implemented in `0.15.4` for the official clients [such as this go implementation](https://github.com/tigerbeetle/tigerbeetle/commit/c0d336bab404dcff3b64e0ae473a7c2c78663569).

I am inexperienced with `c` `ffi` bindings at this level, so please help me double-check the memory management.

Any other feedback is welcome.

Fixed #18 