### PR TITLE
Use `derive_more` to avoid boilerplate in core definitions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -180,6 +180,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_more"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a9b99b9cbbe49445b21764dc0625032a89b145a2642e67603e1c936f5458d05"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.71",
+ "unicode-xid",
+]
+
+[[package]]
 name = "either"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -546,6 +567,7 @@ name = "tigerbeetle-unofficial-core"
 version = "0.4.1+0.15.3"
 dependencies = [
  "bytemuck",
+ "derive_more",
  "sptr",
  "tigerbeetle-unofficial-sys",
  "tokio",
@@ -581,6 +603,12 @@ name = "unicode-ident"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "vcpkg"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -15,6 +15,7 @@ tokio-rt-multi-thread = ["dep:tokio", "tokio/rt-multi-thread"]
 tokio = ["dep:tokio"]
 
 [dependencies]
+derive_more = { version = "1.0", features = ["as_ref", "display", "error", "from"] }
 sys = { version = "0.4.1", package = "tigerbeetle-unofficial-sys", path = "../sys", features = ["generated-safe"] }
 bytemuck = "1.13.1"
 sptr = "0.3.2"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -15,7 +15,7 @@ tokio-rt-multi-thread = ["dep:tokio", "tokio/rt-multi-thread"]
 tokio = ["dep:tokio"]
 
 [dependencies]
-derive_more = { version = "1.0", features = ["as_ref", "display", "error", "from"] }
+derive_more = { version = "1.0", features = ["as_ref", "display", "error", "from", "into"] }
 sys = { version = "0.4.1", package = "tigerbeetle-unofficial-sys", path = "../sys", features = ["generated-safe"] }
 bytemuck = "1.13.1"
 sptr = "0.3.2"

--- a/core/src/account/balance.rs
+++ b/core/src/account/balance.rs
@@ -1,16 +1,20 @@
-use std::time::{Duration, SystemTime};
+use std::{
+    fmt,
+    time::{Duration, SystemTime},
+};
 
 use bytemuck::{Pod, TransparentWrapper, Zeroable};
+use derive_more::{From, Into};
 
 pub use sys::tb_account_balance_t as Raw;
 
+#[derive(Clone, Copy, From, Into, Pod, TransparentWrapper, Zeroable)]
 #[repr(transparent)]
-#[derive(Clone, Copy, TransparentWrapper, Pod, Zeroable)]
 pub struct Balance(Raw);
 
 impl Balance {
     pub const fn from_raw(raw: Raw) -> Self {
-        Balance(raw)
+        Self(raw)
     }
     pub const fn into_raw(self) -> Raw {
         self.0
@@ -71,8 +75,8 @@ impl Balance {
     }
 }
 
-impl std::fmt::Debug for Balance {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl fmt::Debug for Balance {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("AccountBalance")
             .field("debits_pending", &self.0.debits_pending)
             .field("debits_posted", &self.0.debits_posted)
@@ -80,16 +84,5 @@ impl std::fmt::Debug for Balance {
             .field("credits_pending", &self.0.credits_pending)
             .field("timestamp", &self.0.timestamp)
             .finish_non_exhaustive()
-    }
-}
-
-impl From<Raw> for Balance {
-    fn from(value: Raw) -> Self {
-        Balance(value)
-    }
-}
-impl From<Balance> for Raw {
-    fn from(value: Balance) -> Self {
-        value.0
     }
 }

--- a/core/src/account/filter.rs
+++ b/core/src/account/filter.rs
@@ -1,36 +1,27 @@
-use std::time::{Duration, SystemTime};
+use std::{
+    fmt,
+    time::{Duration, SystemTime},
+};
 
 use bytemuck::{Pod, TransparentWrapper, Zeroable};
+use derive_more::{From, Into};
 
-pub use sys::generated_safe::AccountFilterFlags as Flags;
-pub use sys::tb_account_filter_t as Raw;
+pub use sys::{generated_safe::AccountFilterFlags as Flags, tb_account_filter_t as Raw};
 
+#[derive(Clone, Copy, From, Into, Pod, TransparentWrapper, Zeroable)]
 #[repr(transparent)]
-#[derive(Clone, Copy, TransparentWrapper, Pod, Zeroable)]
 pub struct Filter(Raw);
-
-impl std::fmt::Debug for Filter {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("AccountFilter")
-            .field("account_id", &self.0.account_id)
-            .field("timestamp_min", &self.timestamp_min())
-            .field("timestamp_max", &self.timestamp_max())
-            .field("limit", &self.0.limit)
-            .field("flags", &self.flags())
-            .finish_non_exhaustive()
-    }
-}
 
 impl Filter {
     #[track_caller]
     pub fn new(account_id: u128, limit: u32) -> Self {
-        Filter(Raw::zeroed())
+        Self(Raw::zeroed())
             .with_account_id(account_id)
             .with_limit(limit)
     }
 
     pub const fn from_raw(raw: Raw) -> Self {
-        Filter(raw)
+        Self(raw)
     }
     pub const fn into_raw(self) -> Raw {
         self.0
@@ -112,13 +103,14 @@ impl Filter {
     }
 }
 
-impl From<Raw> for Filter {
-    fn from(value: Raw) -> Self {
-        Filter(value)
-    }
-}
-impl From<Filter> for Raw {
-    fn from(value: Filter) -> Self {
-        value.0
+impl fmt::Debug for Filter {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("AccountFilter")
+            .field("account_id", &self.0.account_id)
+            .field("timestamp_min", &self.timestamp_min())
+            .field("timestamp_max", &self.timestamp_max())
+            .field("limit", &self.0.limit)
+            .field("flags", &self.flags())
+            .finish_non_exhaustive()
     }
 }

--- a/core/src/account/mod.rs
+++ b/core/src/account/mod.rs
@@ -1,17 +1,23 @@
-use std::time::{Duration, SystemTime};
-
-use bytemuck::{Pod, TransparentWrapper, Zeroable};
-
 mod balance;
 mod filter;
 
-pub use balance::{Balance, Raw as RawBalance};
-pub use filter::{Filter, Flags as FilterFlags, Raw as RawFilter};
-pub use sys::generated_safe::AccountFlags as Flags;
-pub use sys::tb_account_t as Raw;
+use std::{
+    fmt,
+    time::{Duration, SystemTime},
+};
 
+use bytemuck::{Pod, TransparentWrapper, Zeroable};
+use derive_more::{From, Into};
+
+pub use sys::{generated_safe::AccountFlags as Flags, tb_account_t as Raw};
+
+pub use self::{
+    balance::{Balance, Raw as RawBalance},
+    filter::{Filter, Flags as FilterFlags, Raw as RawFilter},
+};
+
+#[derive(Clone, Copy, From, Into, Pod, TransparentWrapper, Zeroable)]
 #[repr(transparent)]
-#[derive(Clone, Copy, TransparentWrapper, Pod, Zeroable)]
 pub struct Account(Raw);
 
 impl Account {
@@ -145,8 +151,8 @@ impl Account {
     }
 }
 
-impl std::fmt::Debug for Account {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl fmt::Debug for Account {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Account")
             .field("id", &self.id())
             .field("debits_pending", &self.debits_pending())
@@ -161,16 +167,5 @@ impl std::fmt::Debug for Account {
             .field("flags", &self.flags())
             .field("timestamp", &self.timestamp())
             .finish_non_exhaustive()
-    }
-}
-
-impl From<Raw> for Account {
-    fn from(value: Raw) -> Self {
-        Account(value)
-    }
-}
-impl From<Account> for Raw {
-    fn from(value: Account) -> Self {
-        value.0
     }
 }

--- a/core/src/callback.rs
+++ b/core/src/callback.rs
@@ -1,8 +1,6 @@
 use std::{marker::PhantomData, panic::catch_unwind, slice};
 
-use crate::util::RawConstPtr;
-
-use super::Packet;
+use crate::{util::RawConstPtr, Packet};
 
 pub trait CallbacksPtr: RawConstPtr<Target = Self::Pointee> + callbacks_ptr::Sealed {
     type Pointee: Callbacks<UserDataPtr = Self::UserDataPtr> + Sized;

--- a/core/src/error.rs
+++ b/core/src/error.rs
@@ -1,25 +1,30 @@
-use std::mem;
-use std::num::{NonZeroU32, NonZeroU8};
-
-pub use sys::generated_safe::{
-    self as sys_safe, CreateAccountErrorKind, CreateTransferErrorKind,
-    PacketAcquireStatusErrorKind as AcquirePacketErrorKind, PacketStatusErrorKind as SendErrorKind,
-    StatusErrorKind as NewClientErrorKind,
+use std::{
+    fmt, mem,
+    num::{NonZeroU32, NonZeroU8},
 };
-pub use sys::tb_create_accounts_result_t as RawCreateAccountsIndividualApiResult;
-pub use sys::tb_create_transfers_result_t as RawCreateTransfersIndividualApiResult;
 
-#[derive(Clone, Copy)]
-pub struct NewClientError(pub(crate) NonZeroU32);
+use derive_more::{AsRef, Display, Error as StdError, From};
 
-#[derive(Clone, Copy)]
-pub struct AcquirePacketError(pub(crate) NonZeroU32);
+pub use sys::{
+    generated_safe::{
+        self as sys_safe, CreateAccountErrorKind, CreateTransferErrorKind,
+        PacketStatusErrorKind as SendErrorKind, StatusErrorKind as NewClientErrorKind,
+    },
+    tb_create_accounts_result_t as RawCreateAccountsIndividualApiResult,
+    tb_create_transfers_result_t as RawCreateTransfersIndividualApiResult,
+};
 
-#[derive(Clone, Copy)]
-pub struct SendError(pub(crate) NonZeroU8);
+#[derive(Clone, Copy, Display, StdError)]
+#[display("{:?}", self.kind())]
+pub struct NewClientError(#[error(not(source))] pub(crate) NonZeroU32);
 
-#[derive(Clone, Copy)]
-pub struct CreateAccountError(pub(crate) NonZeroU32);
+#[derive(Clone, Copy, Display, StdError)]
+#[display("error occured while sending packets")]
+pub struct SendError(#[error(not(source))] pub(crate) NonZeroU8);
+
+#[derive(Clone, Copy, Display, StdError)]
+#[display("{:?}", self.kind())]
+pub struct CreateAccountError(#[error(not(source))] pub(crate) NonZeroU32);
 
 /// Type indicating individual api error for account creation.
 ///
@@ -27,23 +32,35 @@ pub struct CreateAccountError(pub(crate) NonZeroU32);
 /// if [`Self::from_raw_result_unchecked`] would also be safe.
 //
 // INVARIANT: self.0.result must not be zero
+#[derive(Clone, Copy, Display, StdError)]
+#[display(
+    "`{}` error occured at account with index {}",
+    self.inner(),
+    self.index(),
+)]
 #[repr(transparent)]
-#[derive(Clone, Copy)]
-pub struct CreateAccountsIndividualApiError(RawCreateAccountsIndividualApiResult);
+pub struct CreateAccountsIndividualApiError(
+    #[error(not(source))] RawCreateAccountsIndividualApiResult,
+);
 
 // INVARIANT: self.0 must not be empty
-#[derive(Debug)]
+#[derive(Clone, Debug, Display)]
+#[display(
+    "{} api errors occured at accounts' creation", self.0.len(),
+)]
 pub struct CreateAccountsApiError(Vec<CreateAccountsIndividualApiError>);
 
+#[derive(Clone, Debug, Display, From, StdError)]
 #[non_exhaustive]
-#[derive(Debug)]
 pub enum CreateAccountsError {
-    Send(SendError),
     Api(CreateAccountsApiError),
+    #[display("failed to create accounts: {_0}")]
+    Send(SendError),
 }
 
-#[derive(Clone, Copy)]
-pub struct CreateTransferError(pub(crate) NonZeroU32);
+#[derive(Clone, Copy, Display, StdError)]
+#[display("{:?}", self.kind())]
+pub struct CreateTransferError(#[error(not(source))] pub(crate) NonZeroU32);
 
 /// Type indicating individual api error for account creation.
 ///
@@ -51,19 +68,31 @@ pub struct CreateTransferError(pub(crate) NonZeroU32);
 /// if [`Self::from_raw_result_unchecked`] would also be safe.
 //
 // INVARIANT: self.0.result must not be zero
+#[derive(Clone, Copy, Display, StdError)]
+#[display(
+    "`{}` error occured at account with index {}",
+    self.inner(),
+    self.index(),
+)]
 #[repr(transparent)]
-#[derive(Clone, Copy)]
-pub struct CreateTransfersIndividualApiError(RawCreateTransfersIndividualApiResult);
+pub struct CreateTransfersIndividualApiError(
+    #[error(not(source))] RawCreateTransfersIndividualApiResult,
+);
 
 // INVARIANT: self.0 must not be empty
-#[derive(Debug)]
+#[derive(Clone, Debug, Display)]
+#[display(
+    "{} api errors occured at transfers' creation",
+    self.0.len(),
+)]
 pub struct CreateTransfersApiError(Vec<CreateTransfersIndividualApiError>);
 
+#[derive(Clone, Debug, Display, From, StdError)]
 #[non_exhaustive]
-#[derive(Debug)]
 pub enum CreateTransfersError {
-    Send(SendError),
     Api(CreateTransfersApiError),
+    #[display("failed to create transfers: {_0}")]
+    Send(SendError),
 }
 
 impl NewClientError {
@@ -74,7 +103,7 @@ impl NewClientError {
         let code = self.0.get();
         if Self::CODE_RANGE.contains(&code) {
             // SAFETY: We checked if it's in range right above
-            unsafe { std::mem::transmute(code) }
+            unsafe { mem::transmute(code) }
         } else {
             NewClientErrorKind::UnstableUncategorized
         }
@@ -85,86 +114,32 @@ impl NewClientError {
     }
 }
 
-impl std::fmt::Debug for NewClientError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let code = self.0.get();
+impl fmt::Debug for NewClientError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut d = f.debug_tuple("NewClientErrorError");
-        if Self::CODE_RANGE.contains(&code) {
-            d.field(&self.kind());
-        } else {
+        let kind = self.kind();
+        if matches!(kind, NewClientErrorKind::UnstableUncategorized) {
+            let code = self.code().get();
             d.field(&code);
+        } else {
+            d.field(&kind);
         }
         d.finish()
     }
 }
-
-impl std::fmt::Display for NewClientError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{:?}", self.kind())
-    }
-}
-
-impl std::error::Error for NewClientError {}
 
 impl From<NewClientErrorKind> for NewClientError {
+    /// Constructs a [`NewClientError`] out of [`NewClientErrorKind`].
+    ///
+    /// # Panics
+    ///
     /// Panics on hidden `NewClientErrorKind::UnstableUncategorized` variant.
     fn from(value: NewClientErrorKind) -> Self {
-        let code = value as _;
-        if !Self::CODE_RANGE.contains(&code) {
+        let this = Self(NonZeroU32::new(value as _).unwrap());
+        if matches!(this.kind(), NewClientErrorKind::UnstableUncategorized) {
             panic!("NewClientErrorKind::{value:?}")
         }
-        NewClientError(NonZeroU32::new(code).unwrap())
-    }
-}
-
-impl AcquirePacketError {
-    const CODE_RANGE: std::ops::RangeInclusive<u32> = sys_safe::MIN_PACKET_ACQUIRE_STATUS_ERROR_CODE
-        ..=sys_safe::MAX_PACKET_ACQUIRE_STATUS_ERROR_CODE;
-
-    pub fn kind(self) -> AcquirePacketErrorKind {
-        let code = self.0.get();
-        if Self::CODE_RANGE.contains(&code) {
-            // SAFETY: We checked if it's in range right above
-            unsafe { std::mem::transmute(code) }
-        } else {
-            AcquirePacketErrorKind::UnstableUncategorized
-        }
-    }
-
-    pub fn code(self) -> NonZeroU32 {
-        self.0
-    }
-}
-
-impl std::fmt::Debug for AcquirePacketError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let code = self.0.get();
-        let mut d = f.debug_tuple("AcquirePacketErrorError");
-        if Self::CODE_RANGE.contains(&code) {
-            d.field(&self.kind());
-        } else {
-            d.field(&code);
-        }
-        d.finish()
-    }
-}
-
-impl std::fmt::Display for AcquirePacketError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{:?}", self.kind())
-    }
-}
-
-impl std::error::Error for AcquirePacketError {}
-
-impl From<AcquirePacketErrorKind> for AcquirePacketError {
-    /// Panics on hidden `AcquirePacketErrorKind::UnstableUncategorized` variant.
-    fn from(value: AcquirePacketErrorKind) -> Self {
-        let code = value as _;
-        if !Self::CODE_RANGE.contains(&code) {
-            panic!("AcquirePacketErrorKind::{value:?}")
-        }
-        AcquirePacketError(NonZeroU32::new(code).unwrap())
+        this
     }
 }
 
@@ -176,7 +151,7 @@ impl SendError {
         let code = self.0.get();
         if Self::CODE_RANGE.contains(&code) {
             // SAFETY: We checked if it's in range right above
-            unsafe { std::mem::transmute(code) }
+            unsafe { mem::transmute(code) }
         } else {
             SendErrorKind::UnstableUncategorized
         }
@@ -187,35 +162,32 @@ impl SendError {
     }
 }
 
-impl std::fmt::Debug for SendError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let code = self.0.get();
+impl fmt::Debug for SendError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut d = f.debug_tuple("SendError");
-        if Self::CODE_RANGE.contains(&code) {
-            d.field(&self.kind());
-        } else {
+        let kind = self.kind();
+        if matches!(kind, SendErrorKind::UnstableUncategorized) {
+            let code = self.code().get();
             d.field(&code);
+        } else {
+            d.field(&kind);
         }
         d.finish()
     }
 }
 
-impl std::fmt::Display for SendError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{:?}", self.kind())
-    }
-}
-
-impl std::error::Error for SendError {}
-
 impl From<SendErrorKind> for SendError {
+    /// Constructs a [`SendError`] out of [`SendErrorKind`].
+    ///
+    /// # Panics
+    ///
     /// Panics on hidden `SendErrorKind::UnstableUncategorized` variant.
     fn from(value: SendErrorKind) -> Self {
-        let code = value as _;
-        if !Self::CODE_RANGE.contains(&code) {
+        let this = Self(NonZeroU8::new(value as _).unwrap());
+        if matches!(this.kind(), SendErrorKind::UnstableUncategorized) {
             panic!("SendErrorKind::{value:?}")
         }
-        SendError(NonZeroU8::new(code).unwrap())
+        this
     }
 }
 
@@ -227,7 +199,7 @@ impl CreateAccountError {
         let code = self.0.get();
         if Self::CODE_RANGE.contains(&code) {
             // SAFETY: We checked if it's in range right above
-            unsafe { std::mem::transmute(code) }
+            unsafe { mem::transmute(code) }
         } else {
             CreateAccountErrorKind::UnstableUncategorized
         }
@@ -238,35 +210,32 @@ impl CreateAccountError {
     }
 }
 
-impl std::fmt::Debug for CreateAccountError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let code = self.0.get();
+impl fmt::Debug for CreateAccountError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut d = f.debug_tuple("CreateAccountError");
-        if Self::CODE_RANGE.contains(&code) {
-            d.field(&self.kind());
-        } else {
+        let kind = self.kind();
+        if matches!(kind, CreateAccountErrorKind::UnstableUncategorized) {
+            let code = self.0.get();
             d.field(&code);
+        } else {
+            d.field(&kind);
         }
         d.finish()
     }
 }
 
-impl std::fmt::Display for CreateAccountError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{:?}", self.kind())
-    }
-}
-
-impl std::error::Error for CreateAccountError {}
-
 impl From<CreateAccountErrorKind> for CreateAccountError {
+    /// Constructs a [`CreateAccountError`] out of [`CreateAccountErrorKind`].
+    ///
+    /// # Panics
+    ///
     /// Panics on hidden `CreateAccountErrorKind::UnstableUncategorized` variant.
     fn from(value: CreateAccountErrorKind) -> Self {
-        let code = value as _;
-        if !Self::CODE_RANGE.contains(&code) {
+        let this = Self(NonZeroU32::new(value as _).unwrap());
+        if matches!(this.kind(), CreateAccountErrorKind::UnstableUncategorized) {
             panic!("CreateAccountErrorKind::{value:?}")
         }
-        CreateAccountError(NonZeroU32::new(code).unwrap())
+        this
     }
 }
 
@@ -277,7 +246,7 @@ impl CreateAccountsIndividualApiError {
     ///
     /// Returns `None` if `raw.result` is zero.
     pub fn from_raw_result(raw: RawCreateAccountsIndividualApiResult) -> Option<Self> {
-        (raw.result != 0).then_some(CreateAccountsIndividualApiError(raw))
+        (raw.result != 0).then_some(Self(raw))
     }
 
     /// Create error from raw result. Unchecked version of [`Self::from_raw_result`].
@@ -286,7 +255,7 @@ impl CreateAccountsIndividualApiError {
     ///
     /// This function is unsafe. `raw.result` must not be zero.
     pub unsafe fn from_raw_result_unchecked(raw: RawCreateAccountsIndividualApiResult) -> Self {
-        CreateAccountsIndividualApiError(raw)
+        Self(raw)
     }
 
     /// Create vec of errors from vec of raw results.
@@ -337,27 +306,14 @@ impl CreateAccountsIndividualApiError {
     }
 }
 
-impl std::fmt::Debug for CreateAccountsIndividualApiError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("CreateAccountsError")
+impl fmt::Debug for CreateAccountsIndividualApiError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("CreateAccountsIndividualApiError")
             .field("index", &self.index())
             .field("inner", &self.inner())
             .finish()
     }
 }
-
-impl std::fmt::Display for CreateAccountsIndividualApiError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "`{}` error occured at account with index {}",
-            self.inner(),
-            self.index()
-        )
-    }
-}
-
-impl std::error::Error for CreateAccountsIndividualApiError {}
 
 impl CreateAccountsApiError {
     /// Get a slice of individual errors. Never empty.
@@ -388,18 +344,8 @@ impl AsRef<[CreateAccountsIndividualApiError]> for CreateAccountsApiError {
     }
 }
 
-impl std::fmt::Display for CreateAccountsApiError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "{} api errors occured at accounts' creation",
-            self.0.len()
-        )
-    }
-}
-
-impl std::error::Error for CreateAccountsApiError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+impl StdError for CreateAccountsApiError {
+    fn source(&self) -> Option<&(dyn StdError + 'static)> {
         self.0.first().map(|e| e as _)
     }
 }
@@ -407,39 +353,6 @@ impl std::error::Error for CreateAccountsApiError {
 impl From<CreateAccountsIndividualApiError> for CreateAccountsApiError {
     fn from(value: CreateAccountsIndividualApiError) -> Self {
         CreateAccountsApiError(vec![value])
-    }
-}
-
-impl std::error::Error for CreateAccountsError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        Some(match self {
-            CreateAccountsError::Send(e) => e as _,
-            CreateAccountsError::Api(e) => e as _,
-        })
-    }
-}
-
-impl std::fmt::Display for CreateAccountsError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            CreateAccountsError::Send(_) => {
-                "error occured while sending packets for accounts' creation"
-            }
-            CreateAccountsError::Api(_) => "api errors occured at accounts' creation",
-        }
-        .fmt(f)
-    }
-}
-
-impl From<SendError> for CreateAccountsError {
-    fn from(value: SendError) -> Self {
-        CreateAccountsError::Send(value)
-    }
-}
-
-impl From<CreateAccountsApiError> for CreateAccountsError {
-    fn from(value: CreateAccountsApiError) -> Self {
-        CreateAccountsError::Api(value)
     }
 }
 
@@ -451,7 +364,7 @@ impl CreateTransferError {
         let code = self.0.get();
         if Self::CODE_RANGE.contains(&code) {
             // SAFETY: We checked if it's in range right above
-            unsafe { std::mem::transmute(code) }
+            unsafe { mem::transmute(code) }
         } else {
             CreateTransferErrorKind::UnstableUncategorized
         }
@@ -462,35 +375,32 @@ impl CreateTransferError {
     }
 }
 
-impl std::fmt::Debug for CreateTransferError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let code = self.0.get();
+impl fmt::Debug for CreateTransferError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut d = f.debug_tuple("CreateTransferError");
-        if Self::CODE_RANGE.contains(&code) {
-            d.field(&self.kind());
-        } else {
+        let kind = self.kind();
+        if matches!(kind, CreateTransferErrorKind::UnstableUncategorized) {
+            let code = self.code().get();
             d.field(&code);
+        } else {
+            d.field(&kind);
         }
         d.finish()
     }
 }
 
-impl std::fmt::Display for CreateTransferError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{:?}", self.kind())
-    }
-}
-
-impl std::error::Error for CreateTransferError {}
-
 impl From<CreateTransferErrorKind> for CreateTransferError {
+    /// Constructs a [`CreateTransferError`] out of [`CreateTransferErrorKind`].
+    ///
+    /// # Panics
+    ///
     /// Panics on hidden `CreateTransferErrorKind::UnstableUncategorized` variant.
     fn from(value: CreateTransferErrorKind) -> Self {
-        let code = value as _;
-        if !Self::CODE_RANGE.contains(&code) {
+        let this = Self(NonZeroU32::new(value as _).unwrap());
+        if matches!(this.kind(), CreateTransferErrorKind::UnstableUncategorized) {
             panic!("CreateTransferErrorKind::{value:?}")
         }
-        CreateTransferError(NonZeroU32::new(code).unwrap())
+        this
     }
 }
 
@@ -501,7 +411,7 @@ impl CreateTransfersIndividualApiError {
     ///
     /// Returns `None` if `raw.result` is zero.
     pub fn from_raw_result(raw: RawCreateTransfersIndividualApiResult) -> Option<Self> {
-        (raw.result != 0).then_some(CreateTransfersIndividualApiError(raw))
+        (raw.result != 0).then_some(Self(raw))
     }
 
     /// Create error from raw struct. Unchecked version of [`Self::from_raw_result`].
@@ -510,7 +420,7 @@ impl CreateTransfersIndividualApiError {
     ///
     /// This function is unsafe. `raw.result` must not be zero.
     pub unsafe fn from_raw_result_unchecked(raw: RawCreateTransfersIndividualApiResult) -> Self {
-        CreateTransfersIndividualApiError(raw)
+        Self(raw)
     }
 
     /// Create vec of errors from vec of raw results.
@@ -561,27 +471,14 @@ impl CreateTransfersIndividualApiError {
     }
 }
 
-impl std::fmt::Debug for CreateTransfersIndividualApiError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("CreateTransfersError")
+impl fmt::Debug for CreateTransfersIndividualApiError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("CreateTransfersIndividualApiError")
             .field("index", &self.index())
             .field("inner", &self.inner())
             .finish()
     }
 }
-
-impl std::fmt::Display for CreateTransfersIndividualApiError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "`{}` error occured at account with index {}",
-            self.inner(),
-            self.index()
-        )
-    }
-}
-
-impl std::error::Error for CreateTransfersIndividualApiError {}
 
 impl CreateTransfersApiError {
     /// Get a slice of individual errors. Never empty.
@@ -612,57 +509,14 @@ impl AsRef<[CreateTransfersIndividualApiError]> for CreateTransfersApiError {
     }
 }
 
-impl std::fmt::Display for CreateTransfersApiError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "{} api errors occured at transfers' creation",
-            self.0.len()
-        )
-    }
-}
-
-impl std::error::Error for CreateTransfersApiError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+impl StdError for CreateTransfersApiError {
+    fn source(&self) -> Option<&(dyn StdError + 'static)> {
         self.0.first().map(|e| e as _)
     }
 }
 
 impl From<CreateTransfersIndividualApiError> for CreateTransfersApiError {
     fn from(value: CreateTransfersIndividualApiError) -> Self {
-        CreateTransfersApiError(vec![value])
-    }
-}
-
-impl std::error::Error for CreateTransfersError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        Some(match self {
-            CreateTransfersError::Send(e) => e as _,
-            CreateTransfersError::Api(e) => e as _,
-        })
-    }
-}
-
-impl std::fmt::Display for CreateTransfersError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            CreateTransfersError::Send(_) => {
-                "error occured while sending packets for transfers' creation"
-            }
-            CreateTransfersError::Api(_) => "api errors occured at transfers' creation",
-        }
-        .fmt(f)
-    }
-}
-
-impl From<SendError> for CreateTransfersError {
-    fn from(value: SendError) -> Self {
-        CreateTransfersError::Send(value)
-    }
-}
-
-impl From<CreateTransfersApiError> for CreateTransfersError {
-    fn from(value: CreateTransfersApiError) -> Self {
-        CreateTransfersError::Api(value)
+        Self(vec![value])
     }
 }

--- a/core/src/handle.rs
+++ b/core/src/handle.rs
@@ -18,8 +18,10 @@ where
 unsafe impl<U> Send for ClientHandle<'_, U> where U: UserDataPtr {}
 unsafe impl<U> Sync for ClientHandle<'_, U> where U: UserDataPtr {}
 
+// Manual implementation is done to avoid redundant `U: Copy` bound.
 impl<U> Copy for ClientHandle<'_, U> where U: UserDataPtr {}
 
+// Manual implementation is done to avoid redundant `U: Clone` bound.
 impl<U> Clone for ClientHandle<'_, U>
 where
     U: UserDataPtr,

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -10,11 +10,13 @@ use std::{marker::PhantomData, mem, num::NonZeroU32};
 
 use error::{AcquirePacketError, NewClientError, NewClientErrorKind};
 
-pub use account::Account;
-pub use callback::*;
-pub use handle::ClientHandle;
-pub use packet::*;
-pub use transfer::Transfer;
+pub use self::{
+    account::Account,
+    callback::{on_completion_fn, Callbacks, CallbacksFn, CallbacksPtr, UserData, UserDataPtr},
+    handle::ClientHandle,
+    packet::{Operation, OperationKind, Packet},
+    transfer::Transfer,
+};
 
 type OnCompletionRawFn =
     unsafe extern "C" fn(usize, sys::tb_client_t, *mut sys::tb_packet_t, *const u8, u32);

--- a/core/src/transfer.rs
+++ b/core/src/transfer.rs
@@ -1,12 +1,15 @@
-use std::time::{Duration, SystemTime};
+use std::{
+    fmt,
+    time::{Duration, SystemTime},
+};
 
 use bytemuck::{Pod, TransparentWrapper, Zeroable};
+use derive_more::{From, Into};
 
-pub use sys::generated_safe::TransferFlags as Flags;
-pub use sys::tb_transfer_t as Raw;
+pub use sys::{generated_safe::TransferFlags as Flags, tb_transfer_t as Raw};
 
+#[derive(Clone, Copy, From, Into, Pod, TransparentWrapper, Zeroable)]
 #[repr(transparent)]
-#[derive(Clone, Copy, TransparentWrapper, Pod, Zeroable)]
 pub struct Transfer(Raw);
 
 impl Transfer {
@@ -175,8 +178,8 @@ impl Transfer {
     }
 }
 
-impl std::fmt::Debug for Transfer {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl fmt::Debug for Transfer {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Transfer")
             .field("id", &self.id())
             .field("debit_account_id", &self.debit_account_id())
@@ -192,16 +195,5 @@ impl std::fmt::Debug for Transfer {
             .field("flags", &self.flags())
             .field("timestamp", &self.timestamp())
             .finish_non_exhaustive()
-    }
-}
-
-impl From<Raw> for Transfer {
-    fn from(value: Raw) -> Self {
-        Transfer(value)
-    }
-}
-impl From<Transfer> for Raw {
-    fn from(value: Transfer) -> Self {
-        value.0
     }
 }

--- a/core/src/util.rs
+++ b/core/src/util.rs
@@ -4,6 +4,8 @@ mod owned_slice;
 mod raw_const_ptr;
 pub mod send_marker;
 
-pub use owned_slice::*;
-pub use raw_const_ptr::RawConstPtr;
-pub use send_marker::SendMarker;
+pub use self::{
+    owned_slice::{AsBytesOwnedSlice, Erased, OwnedSlice, SendAsBytesOwnedSlice, SendOwnedSlice},
+    raw_const_ptr::RawConstPtr,
+    send_marker::SendMarker,
+};

--- a/sys/build.rs
+++ b/sys/build.rs
@@ -16,13 +16,13 @@ const TIGERBEETLE_RELEASE: &str = "0.15.3";
 
 fn target_to_lib_dir(target: &str) -> Option<&'static str> {
     match target {
+        "aarch64-apple-darwin" => Some("aarch64-macos"),
         "aarch64-unknown-linux-gnu" => Some("aarch64-linux-gnu"),
         "aarch64-unknown-linux-musl" => Some("aarch64-linux-musl"),
-        "aarch64-apple-darwin" => Some("aarch64-macos"),
-        "x86_64-unknown-linux-gnu" => Some("x86_64-linux-gnu"),
-        "x86_64-unknown-linux-musl" => Some("x86_64-linux-musl"),
         "x86_64-apple-darwin" => Some("x86_64-macos"),
         "x86_64-pc-windows-msvc" => Some("x86_64-windows"),
+        "x86_64-unknown-linux-gnu" => Some("x86_64-linux-gnu"),
+        "x86_64-unknown-linux-musl" => Some("x86_64-linux-musl"),
         _ => None,
     }
 }
@@ -247,8 +247,13 @@ impl Visit<'_> for TigerbeetleVisitor {
                     errorize = true;
                 }
                 match new_enum_name.as_str() {
-                    "Status" => {
-                        new_enum_name = "StatusErrorKind".to_string();
+                    "Operation" => {
+                        new_enum_name = "OperationKind".to_string();
+                        new_enum_ident = syn::Ident::new(&new_enum_name, new_enum_ident.span());
+                        repr_type = "u8"
+                    }
+                    "PacketAcquireStatus" => {
+                        new_enum_name = "PacketAcquireStatusErrorKind".to_string();
                         new_enum_ident = syn::Ident::new(&new_enum_name, new_enum_ident.span());
                         errorize = true;
                     }
@@ -258,15 +263,10 @@ impl Visit<'_> for TigerbeetleVisitor {
                         repr_type = "u8";
                         errorize = true;
                     }
-                    "PacketAcquireStatus" => {
-                        new_enum_name = "PacketAcquireStatusErrorKind".to_string();
+                    "Status" => {
+                        new_enum_name = "StatusErrorKind".to_string();
                         new_enum_ident = syn::Ident::new(&new_enum_name, new_enum_ident.span());
                         errorize = true;
-                    }
-                    "Operation" => {
-                        new_enum_name = "OperationKind".to_string();
-                        new_enum_ident = syn::Ident::new(&new_enum_name, new_enum_ident.span());
-                        repr_type = "u8"
                     }
                     _ => (),
                 }
@@ -397,12 +397,12 @@ impl bindgen::callbacks::ParseCallbacks for TigerbeetleCallbacks {
         if let bindgen::callbacks::DeriveInfo {
             kind: bindgen::callbacks::TypeKind::Struct,
             name:
-                "tb_account_t"
-                | "tb_account_balance_t"
+                "tb_account_balance_t"
                 | "tb_account_filter_t"
+                | "tb_account_t"
                 | "tb_create_accounts_result_t"
-                | "tb_transfer_t"
-                | "tb_create_transfers_result_t",
+                | "tb_create_transfers_result_t"
+                | "tb_transfer_t",
             ..
         } = info
         {


### PR DESCRIPTION
Reduce boilerplate in `core` crate by using `derive_more` Cargo dependency.