### PR TITLE
Improve Client API ergonomics

### DIFF
--- a/core/examples/c_port_low_level.rs
+++ b/core/examples/c_port_low_level.rs
@@ -51,7 +51,7 @@ fn main() {
         data_size: 0,
     });
     user_data.set_data(accounts);
-    let mut packet = client.packet(user_data, tb::OperationKind::CreateAccounts.into());
+    let mut packet = client.packet(user_data, tb::OperationKind::CreateAccounts);
     println!("Creating accounts...");
     let mut state = CTX.state.lock().unwrap();
     (user_data, state) = CTX.send_request(state, packet).unwrap();
@@ -83,7 +83,7 @@ fn main() {
                 .with_amount(1)
         });
         user_data.set_data(transfers);
-        packet = client.packet(user_data, tb::OperationKind::CreateTransfers.into());
+        packet = client.packet(user_data, tb::OperationKind::CreateTransfers);
 
         let now = Instant::now();
         (user_data, state) = CTX.send_request(state, packet).unwrap();
@@ -121,7 +121,7 @@ fn main() {
     println!("Looking up accounts ...");
     let ids = accounts.map(|a| a.id());
     user_data.set_data(ids);
-    packet = client.packet(user_data, tb::OperationKind::LookupAccounts.into());
+    packet = client.packet(user_data, tb::OperationKind::LookupAccounts);
     (_, state) = CTX.send_request(state, packet).unwrap();
     let accounts = state.get_data::<tb::Account>();
     if accounts.is_empty() {

--- a/core/src/handle.rs
+++ b/core/src/handle.rs
@@ -29,7 +29,7 @@ impl<'a, U> ClientHandle<'a, U>
 where
     U: UserDataPtr,
 {
-    pub fn packet(self, user_data: U, operation: packet::Operation) -> Packet<'a, U> {
+    pub fn packet(self, user_data: U, operation: impl Into<packet::Operation>) -> Packet<'a, U> {
         Packet::new(self, user_data, operation)
     }
 }

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -132,7 +132,7 @@ where
     pub fn packet(
         &self,
         user_data: F::UserDataPtr,
-        operation: packet::Operation,
+        operation: impl Into<packet::Operation>,
     ) -> Packet<'_, F::UserDataPtr> {
         self.handle().packet(user_data, operation)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,7 +45,7 @@ impl Client {
         Ok(self
             .submit(
                 accounts.into_as_bytes(),
-                core::OperationKind::CreateAccounts.into(),
+                core::OperationKind::CreateAccounts,
             )
             .await?
             .into_create_accounts()?)
@@ -62,7 +62,7 @@ impl Client {
         Ok(self
             .submit(
                 transfers.into_as_bytes(),
-                core::OperationKind::CreateTransfers.into(),
+                core::OperationKind::CreateTransfers,
             )
             .await?
             .into_create_transfers()?)
@@ -78,7 +78,7 @@ impl Client {
         let filter: SendOwnedSlice<account::Filter> = SendOwnedSlice::from_single(filter);
         self.submit(
             filter.into_as_bytes(),
-            core::OperationKind::GetAccountBalances.into(),
+            core::OperationKind::GetAccountBalances,
         )
         .await
         .map(Reply::into_get_account_balances)
@@ -91,7 +91,7 @@ impl Client {
         let filter: SendOwnedSlice<account::Filter> = SendOwnedSlice::from_single(filter);
         self.submit(
             filter.into_as_bytes(),
-            core::OperationKind::GetAccountTransfers.into(),
+            core::OperationKind::GetAccountTransfers,
         )
         .await
         .map(Reply::into_get_account_transfers)
@@ -105,12 +105,9 @@ impl Client {
         if ids.is_empty() {
             return Ok(Vec::new());
         }
-        self.submit(
-            ids.into_as_bytes(),
-            core::OperationKind::LookupAccounts.into(),
-        )
-        .await
-        .map(Reply::into_lookup_accounts)
+        self.submit(ids.into_as_bytes(), core::OperationKind::LookupAccounts)
+            .await
+            .map(Reply::into_lookup_accounts)
     }
 
     pub async fn lookup_transfers<T>(&self, ids: T) -> Result<Vec<Transfer>, SendError>
@@ -121,18 +118,15 @@ impl Client {
         if ids.is_empty() {
             return Ok(Vec::new());
         }
-        self.submit(
-            ids.into_as_bytes(),
-            core::OperationKind::LookupTransfers.into(),
-        )
-        .await
-        .map(Reply::into_lookup_transfers)
+        self.submit(ids.into_as_bytes(), core::OperationKind::LookupTransfers)
+            .await
+            .map(Reply::into_lookup_transfers)
     }
 
     async fn submit(
         &self,
         data: SendAsBytesOwnedSlice,
-        operation: core::Operation,
+        operation: impl Into<core::Operation>,
     ) -> Result<Reply, SendError> {
         let (reply_sender, reply_receiver) = oneshot::channel();
         let user_data = Box::new(UserData { reply_sender, data });


### PR DESCRIPTION
Allow to specify `OperationKind` (without converting it to `packet::Operation` manually) in `Client::packet`.