### PR TITLE
Add flags for requests, all using the golang client as a reference

### DIFF
--- a/core/src/account.rs
+++ b/core/src/account.rs
@@ -10,6 +10,16 @@ pub use filter::{Filter, Flags as FilterFlags, Raw as RawFilter};
 pub use sys::generated_safe::AccountFlags as Flags;
 pub use sys::tb_account_t as Raw;
 
+/// copied from https://github.com/tigerbeetle/tigerbeetle-go/blob/127c221992197076a3b1c84e3668c6c36c4a3389/pkg/types/bindings.go#L23
+pub mod flags {
+    pub static LINKED: u16 = 1 << 0;
+    pub static DEBITS_MUST_NOT_EXCEED_CREDITS: u16 = 1 << 1;
+    pub static CREDITS_MUST_NOT_EXCEED_DEBITS: u16 = 1 << 2;
+    pub static HISTORY: u16 = 1 << 3;
+    pub static IMPORTED: u16 = 1 << 4;
+    pub static CLOSED: u16 = 1 << 5;
+}
+
 #[repr(transparent)]
 #[derive(Clone, Copy, TransparentWrapper, Pod, Zeroable)]
 pub struct Account(Raw);

--- a/core/src/account/filter.rs
+++ b/core/src/account/filter.rs
@@ -5,6 +5,13 @@ use bytemuck::{Pod, TransparentWrapper, Zeroable};
 pub use sys::generated_safe::AccountFilterFlags as Flags;
 pub use sys::tb_account_filter_t as Raw;
 
+/// copied from https://github.com/tigerbeetle/tigerbeetle-go/blob/127c221992197076a3b1c84e3668c6c36c4a3389/pkg/types/bindings.go#L113
+pub mod flags {
+    pub static DEBITS: u16 = 1 << 0;
+    pub static CREDITS: u16 = 1 << 1;
+    pub static REVERSED: u16 = 1 << 2;
+}
+
 #[repr(transparent)]
 #[derive(Clone, Copy, TransparentWrapper, Pod, Zeroable)]
 pub struct Filter(Raw);

--- a/core/src/query_filter.rs
+++ b/core/src/query_filter.rs
@@ -8,6 +8,11 @@ use bytemuck::{Pod, TransparentWrapper, Zeroable};
 pub use sys::generated_safe::QueryFilterFlags as Flags;
 pub use sys::tb_query_filter_t as Raw;
 
+/// copied from https://github.com/tigerbeetle/tigerbeetle-go/blob/127c221992197076a3b1c84e3668c6c36c4a3389/pkg/types/bindings.go#L135
+pub mod flags {
+    pub static REVERSED: u16 = 1 << 0;
+}
+
 #[derive(Clone, Copy, Pod, TransparentWrapper, Zeroable)]
 #[repr(transparent)]
 pub struct QueryFilter(Raw);

--- a/core/src/transfer.rs
+++ b/core/src/transfer.rs
@@ -5,6 +5,19 @@ use bytemuck::{Pod, TransparentWrapper, Zeroable};
 pub use sys::generated_safe::TransferFlags as Flags;
 pub use sys::tb_transfer_t as Raw;
 
+// copied from https://github.com/tigerbeetle/tigerbeetle-go/blob/127c221992197076a3b1c84e3668c6c36c4a3389/pkg/types/bindings.go#L65
+pub mod flags {
+    pub static LINKED: u16 = 1 << 0;
+    pub static PENDING: u16 = 1 << 1;
+    pub static POST_PENDING_TRANSFER: u16 = 1 << 2;
+    pub static VOID_PENDING_TRANSFER: u16 = 1 << 3;
+    pub static BALANCING_DEBIT: u16 = 1 << 4;
+    pub static BALANCING_CREDIT: u16 = 1 << 5;
+    pub static CLOSING_DEBIT: u16 = 1 << 6;
+    pub static CLOSING_CREDIT: u16 = 1 << 7;
+    pub static IMPORTED: u16 = 1 << 8;
+}
+
 #[repr(transparent)]
 #[derive(Clone, Copy, TransparentWrapper, Pod, Zeroable)]
 pub struct Transfer(Raw);


### PR DESCRIPTION
The cargo docs say the flags exist but as soon as you click source it links to a 404, here is a rust replacement