### PR TITLE
Fix `sys::tb_client_t` handling inside `core::Client` (#59)

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -15,7 +15,7 @@ pub mod query_filter;
 pub mod transfer;
 pub mod util;
 
-use std::{marker::PhantomData, mem, num::NonZeroU32};
+use std::{marker::PhantomData, mem, num::NonZeroU32, pin::Pin, cell::UnsafeCell};
 
 use error::{NewClientError, NewClientErrorKind};
 
@@ -32,7 +32,7 @@ pub struct Client<F>
 where
     F: CallbacksPtr,
 {
-    raw: sys::tb_client_t,
+    raw: Pin<Box<UnsafeCell<sys::tb_client_t>>>,
     cb: *const F::Target,
     marker: PhantomData<F>,
 }
@@ -87,10 +87,10 @@ where
             address: &[u8],
             completion_ctx: usize,
             completion_callback: CompletionCallbackRawFn,
-        ) -> Result<sys::tb_client_t, NewClientError> {
-            let mut raw = mem::zeroed();
+        ) -> Result<Pin<Box<UnsafeCell<sys::tb_client_t>>>, NewClientError> {
+            let mut raw = Box::pin(UnsafeCell::new(mem::zeroed()));
             let status = sys::tb_client_init(
-                &mut raw,
+                raw.as_mut().get_unchecked_mut().get_mut(),
                 cluster_id.to_ne_bytes().as_ptr(),
                 address.as_ptr().cast(),
                 address
@@ -113,14 +113,8 @@ where
 
         Ok(Client {
             raw: unsafe {
-                match raw_with_callback(cluster_id, address.as_ref(), completion_ctx, completion_fn)
-                {
-                    Ok(x) => x,
-                    Err(e) => {
-                        F::from_raw_const_ptr(completion_cb);
-                        return Err(e);
-                    }
-                }
+                raw_with_callback(cluster_id, address.as_ref(), completion_ctx, completion_fn)
+                    .inspect_err(|_| drop(F::from_raw_const_ptr(completion_cb)))?
             },
             cb: completion_cb,
             marker: PhantomData,
@@ -143,13 +137,14 @@ where
         raw_packet.data_size = data_size;
         raw_packet.data = data.cast_mut().cast();
 
-        let mut raw_client = self.raw;
-
+        // SAFETY: Going from `&self` to `*mut sys::tb_client_t` is OK here, because multi-thread
+        //         access is synchronized by the `sys::tb_client_t` itself inside.
         unsafe {
+            let raw_client: *mut sys::tb_client_t = self.raw.get();
             // NOTE: We do omit checking the result to be `TB_CLIENT_INVALID` intentionally here,
             //       because it can be returned only if the `raw_client` is not yet inited, or was
             //       deinited already, which happens only in constructors and `Drop` respectively.
-            _ = sys::tb_client_submit(&mut raw_client, packet.raw);
+            _ = sys::tb_client_submit(raw_client, packet.raw);
         }
         mem::forget(packet); // avoid `Drop`ping `Packet`
     }
@@ -162,6 +157,7 @@ where
 {
     fn drop(&mut self) {
         unsafe {
+            let raw_client = self.raw.as_mut().get_unchecked_mut().get_mut();
             #[cfg(feature = "tokio-rt-multi-thread")]
             if tokio::runtime::Handle::try_current().is_ok_and(|h| {
                 matches!(
@@ -169,15 +165,16 @@ where
                     tokio::runtime::RuntimeFlavor::MultiThread
                 )
             }) {
-                _ = tokio::task::block_in_place(|| sys::tb_client_deinit(&mut self.raw));
+                _ = tokio::task::block_in_place(|| sys::tb_client_deinit(raw_client));
             } else {
-                _ = sys::tb_client_deinit(&mut self.raw);
+                _ = sys::tb_client_deinit(raw_client);
             }
             #[cfg(not(feature = "tokio-rt-multi-thread"))]
             {
-                _ = sys::tb_client_deinit(&mut self.raw);
+                _ = sys::tb_client_deinit(raw_client);
             }
-            F::from_raw_const_ptr(self.cb);
+
+            drop(F::from_raw_const_ptr(self.cb));
         }
     }
 }

--- a/core/src/util/owned_slice.rs
+++ b/core/src/util/owned_slice.rs
@@ -166,11 +166,11 @@ where
         where
             P: RawConstPtr<Target = [T]> + 'static,
         {
-            P::from_raw_const_ptr(
+            drop(P::from_raw_const_ptr(
                 NonNull::slice_from_raw_parts(ptr.cast::<T>(), len)
                     .as_ptr()
                     .cast_const(),
-            );
+            ));
         }
         let ptr = unsafe { NonNull::new_unchecked(P::into_raw_const_ptr(value).cast_mut()) };
         unsafe { OwnedSlice::from_raw_parts(ptr.cast(), ptr.len(), 0, drop_impl::<P, T>) }
@@ -186,7 +186,7 @@ impl<T: Sized> SendOwnedSlice<T> {
         where
             P: RawConstPtr<Target = T> + 'static,
         {
-            P::from_raw_const_ptr(ptr.as_ptr() as *const T);
+            drop(P::from_raw_const_ptr(ptr.as_ptr() as *const T));
         }
         let ptr = unsafe { NonNull::new_unchecked(P::into_raw_const_ptr(value).cast_mut()) };
         unsafe { OwnedSlice::from_raw_parts(ptr.cast(), 1, 0, drop_impl::<P, T>) }
@@ -202,11 +202,11 @@ where
         where
             P: RawConstPtr<Target = [T]> + 'static,
         {
-            P::from_raw_const_ptr(
+            drop(P::from_raw_const_ptr(
                 NonNull::slice_from_raw_parts(ptr.cast::<T>(), len)
                     .as_ptr()
                     .cast_const(),
-            );
+            ));
         }
         let ptr = unsafe { NonNull::new_unchecked(P::into_raw_const_ptr(value).cast_mut()) };
         unsafe { OwnedSlice::from_raw_parts(ptr.cast(), ptr.len(), 0, drop_impl::<P, T>) }
@@ -221,7 +221,7 @@ impl<T: Sized> OwnedSlice<T> {
         where
             P: RawConstPtr<Target = T> + 'static,
         {
-            P::from_raw_const_ptr(ptr.as_ptr() as *const T);
+            drop(P::from_raw_const_ptr(ptr.as_ptr() as *const T));
         }
         let ptr = unsafe { NonNull::new_unchecked(P::into_raw_const_ptr(value).cast_mut()) };
         unsafe { OwnedSlice::from_raw_parts(ptr.cast(), 1, 0, drop_impl::<P, T>) }


### PR DESCRIPTION
Resolves #59  
Revealed from tigerbeetle/tigerbeetle#2884

## Synopsis 

> I haven't run your code, but it seems like [you're moving the `tb_client_t` handle](https://github.com/tigerbeetle-rust/tigerbeetle-unofficial/blob/6e13d958b92be8c8bfe43710b9c4ba977f3fa7c8/core/src/lib.rs#L91-L111).
> 
> The pointer used to initialize the client must remain pinned through the lifetime of the client instance. You might need to heap allocate it to get a stable reference.
> 
> [tigerbeetle/src/clients/c/tb_client.h](https://github.com/tigerbeetle/tigerbeetle/blob/adcb9ad9c69687c0adb4e20bd0119d24c03459c5/src/clients/c/tb_client.h#L228-L233)
> 
> Lines 228 to 233 in [adcb9ad](/tigerbeetle/tigerbeetle/commit/adcb9ad9c69687c0adb4e20bd0119d24c03459c5)
>  // Opaque struct serving as a handle for the client instance. 
>  // This struct must be "pinned" (not copyable or movable), as its address must remain stable 
>  // throughout the lifetime of the client instance. 
>  typedef struct tb_client_t { 
>      uint64_t opaque[4]; 
>  } tb_client_t; 
> 
> The deadlock-like effect occurs because we're waiting for the wrong mutex to be released as the reference we hold is already gone! Additionally, I _think_ we could assert this and panic instead.

## Solution 

Hold the `sys::tb_client_t` handling inside the `core::Client` as `Pin<Box<UnsafeCell<T>>>`.

