### PR TITLE
Fix panic on `Future` cancellation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ All user visible changes to `tigerbeetle-unofficial`, `tigerbeetle-unofficial-co
 
 
 
+## main
+
+[Diff](https://github.com/tigerbeetle-rust/tigerbeetle-unofficial/compare/v0.13.2%2B0.16.49...main) | [Milestone](https://github.com/tigerbeetle-rust/tigerbeetle-unofficial/milestone/34)
+
+### Fixed
+
+- `core` crate:
+    - `Callbacks` panic on `.submit()` `Future` cancellation. ([#78])
+
+[#78]: https://github.com/tigerbeetle-rust/tigerbeetle-unofficial/pull/78
+
+
+
+
 ## [0.13.2+0.16.49] · 2025-07-08
 [0.13.2+0.16.49]: https://github.com/tigerbeetle-rust/tigerbeetle-unofficial/tree/v0.13.2%2B0.16.49
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -169,12 +169,16 @@ impl core::Callbacks for Callbacks {
         let status = packet.status();
         let operation = packet.operation();
         let user_data = packet.into_user_data();
-        // Channel may be closed due `Future` cancellation so ignore the error.
-        drop(user_data.reply_sender.send(status.map(|()| {
-            // PANIC: Unwrapping is OK here, because the `reply` can only be `None` when the
-            //        `status` is `Err`.
-            Reply::copy_from_reply(operation.kind(), reply.unwrap().payload)
-        })));
+        // Channel may be closed due to the `Future` cancellation, so the `.send()` error should
+        // be ignored.
+        user_data
+            .reply_sender
+            .send(status.map(|()| {
+                // PANIC: Unwrapping is OK here, because the `reply` can only be `None` when the
+                //        `status` is `Err`.
+                Reply::copy_from_reply(operation.kind(), reply.unwrap().payload)
+            }))
+            .unwrap_or_else(drop);
     }
 }
 


### PR DESCRIPTION
## Synopsis

Request `Future` cancellation leads to panic in `Callbacks` implementation.

## Solution

Ignore error of request result receiver being dropped already.